### PR TITLE
Use gql from code-tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   ],
   "dependencies": {
     "classnames": "^2.3.1",
+    "code-tag": "^1.1.0",
     "graphql": "^15.5.0",
     "graphql-request": "^6.1.0",
     "graphql-tag": "^2.11.0",

--- a/src/core/datatype.ts
+++ b/src/core/datatype.ts
@@ -1,4 +1,4 @@
-import { gql } from "graphql-request";
+import { gql } from "code-tag";
 
 type Or<Type, Or> = Type | Or;
 type Maybe<Type> = Or<Type, null | undefined>;

--- a/src/datatypes/Author.ts
+++ b/src/datatypes/Author.ts
@@ -1,4 +1,4 @@
-import { gql } from "graphql-request";
+import { gql } from "code-tag";
 import { createDataType } from "../core/datatype";
 import { Author_ActorFragment } from "../types";
 

--- a/src/datatypes/Comment.ts
+++ b/src/datatypes/Comment.ts
@@ -1,4 +1,4 @@
-import { gql } from "graphql-request";
+import { gql } from "code-tag";
 import { createDataType } from "../core/datatype";
 import { Comment_IssueCommentFragment } from "../types";
 import { Author } from "./Author";

--- a/src/datatypes/Label.ts
+++ b/src/datatypes/Label.ts
@@ -1,4 +1,4 @@
-import { gql } from "graphql-request";
+import { gql } from "code-tag";
 import { createDataType } from "../core/datatype";
 import { Label_LabelFragment } from "../types";
 

--- a/src/datatypes/Labels.ts
+++ b/src/datatypes/Labels.ts
@@ -1,4 +1,4 @@
-import { gql } from "graphql-request";
+import { gql } from "code-tag";
 import { isNonNull } from "../utils/func";
 import { createDataType } from "../core/datatype";
 import { Labels_LabelConnectionFragment } from "../types";

--- a/src/datatypes/PageInfo.ts
+++ b/src/datatypes/PageInfo.ts
@@ -1,4 +1,4 @@
-import { gql } from "graphql-request";
+import { gql } from "code-tag";
 import { createDataType } from "../core/datatype";
 import { PageInfo_PageInfoFragment } from "../types";
 

--- a/src/datatypes/Post.ts
+++ b/src/datatypes/Post.ts
@@ -1,5 +1,5 @@
 import matter from "gray-matter";
-import { gql } from "graphql-request";
+import { gql } from "code-tag";
 import { createDataType } from "../core/datatype";
 import { Post_IssueFragment } from "../types";
 

--- a/src/datatypes/PostReduced.ts
+++ b/src/datatypes/PostReduced.ts
@@ -1,4 +1,4 @@
-import { gql } from "graphql-request";
+import { gql } from "code-tag";
 import { createDataType } from "../core/datatype";
 
 import { Post } from "./Post";

--- a/src/datatypes/Reactions.ts
+++ b/src/datatypes/Reactions.ts
@@ -1,6 +1,6 @@
+import { gql } from "code-tag";
 import { createDataType } from "../core/datatype";
 import { Reactions_ReactionGroupFragment, ReactionContent } from "../types";
-import { gql } from "graphql-request";
 
 export enum Reaction {
   ThumbsUp = "THUMBS_UP",

--- a/src/methods/getComments.ts
+++ b/src/methods/getComments.ts
@@ -1,4 +1,4 @@
-import { gql } from "graphql-request";
+import { gql } from "code-tag";
 import type { Unwrap } from "../types";
 import type { GithubBlog } from "../github-blog";
 import { GithubQueryParams } from "../utils/github-query";

--- a/src/methods/getLabels.ts
+++ b/src/methods/getLabels.ts
@@ -1,4 +1,4 @@
-import { gql } from "graphql-request";
+import { gql } from "code-tag";
 import type { GithubBlog } from "../github-blog";
 import type { Unwrap } from "../types";
 import { isNonNull } from "../utils/func";

--- a/src/methods/getPinnedPosts.ts
+++ b/src/methods/getPinnedPosts.ts
@@ -1,4 +1,4 @@
-import { gql } from "graphql-request";
+import { gql } from "code-tag";
 import type { Unwrap } from "../types";
 import type { GithubBlog } from "../github-blog";
 import { isNonNull } from "../utils/func";

--- a/src/methods/getPost.ts
+++ b/src/methods/getPost.ts
@@ -1,4 +1,4 @@
-import { gql } from "graphql-request";
+import { gql } from "code-tag";
 import type { Unwrap } from "../types";
 import type { GithubBlog } from "../github-blog";
 import { Post } from "../datatypes/Post";

--- a/src/methods/getPosts.ts
+++ b/src/methods/getPosts.ts
@@ -1,4 +1,4 @@
-import { gql } from "graphql-request";
+import { gql } from "code-tag";
 import type { Unwrap } from "../types";
 import type { GithubBlog } from "../github-blog";
 import { GithubQueryParams } from "../utils/github-query";

--- a/yarn.lock
+++ b/yarn.lock
@@ -2342,6 +2342,11 @@ co@^4.6.0:
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
   integrity sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=
 
+code-tag@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/code-tag/-/code-tag-1.1.0.tgz#8dc979c2bd2e2ac44d5a799abd07953e39cadf3d"
+  integrity sha512-qqvyRC9Fmnqy/1nK2Jz6FIk6F24nliVIVtQFg0r7PuZCZHfWO/c7eZHVlPxFKRSnOSIUUf/jrF1FG8j67FinPg==
+
 collect-v8-coverage@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz#cc2c8e94fc18bbdffe64d6534570c8a673b27f59"


### PR DESCRIPTION
I plan to replace graphql-request with undici. Though currently used gql tagged template comes from graphql-request. We need to marker graphql queries for codegen. He're very small package code-tag which includes many conventional tagged templates supported by prettier for example and practically do nothing. String is always an output.