### PR TITLE
Check test types

### DIFF
--- a/e2e/getComments.test.ts
+++ b/e2e/getComments.test.ts
@@ -1,4 +1,4 @@
-import { GithubBlog } from "../dist/github-blog";
+import { GithubBlog } from "../src/github-blog";
 
 const blog = new GithubBlog({
   repo: "renatorib/github-blog-tests",

--- a/e2e/getLabels.test.ts
+++ b/e2e/getLabels.test.ts
@@ -1,4 +1,4 @@
-import { GithubBlog } from "../dist/github-blog";
+import { GithubBlog } from "../src/github-blog";
 
 const blog = new GithubBlog({
   repo: "renatorib/github-blog-tests",

--- a/e2e/getPinnedPosts.test.ts
+++ b/e2e/getPinnedPosts.test.ts
@@ -1,4 +1,4 @@
-import { GithubBlog } from "../dist/github-blog";
+import { GithubBlog } from "../src/github-blog";
 
 const blog = new GithubBlog({
   repo: "renatorib/github-blog-tests",

--- a/e2e/getPost.test.ts
+++ b/e2e/getPost.test.ts
@@ -1,4 +1,4 @@
-import { GithubBlog } from "../dist/github-blog";
+import { GithubBlog } from "../src/github-blog";
 
 const blog = new GithubBlog({
   repo: "renatorib/github-blog-tests",

--- a/e2e/getPosts.test.ts
+++ b/e2e/getPosts.test.ts
@@ -1,4 +1,4 @@
-import { GithubBlog } from "../dist/github-blog";
+import { GithubBlog } from "../src/github-blog";
 
 const blog = new GithubBlog({
   repo: "renatorib/github-blog-tests",

--- a/package.json
+++ b/package.json
@@ -8,12 +8,11 @@
   "author": "Renato Ribeiro <hi@rena.to>",
   "license": "MIT",
   "scripts": {
-    "clean": "rm -rf ./dist",
     "codegen": "graphql-codegen -r dotenv-flow/config",
     "type-check": "tsc --noEmit",
     "dev": "yarn codegen --watch",
-    "build": "yarn codegen && yarn clean && tsc",
-    "e2e": "yarn build && yarn jest --testPathPattern=e2e",
+    "build": "rm -rf ./dist && yarn tsc --project tsconfig.build.json",
+    "e2e": "yarn codegen && yarn jest --testPathPattern=e2e",
     "prepublishOnly": "yarn e2e",
     "debug": "node -r dotenv-flow/config src/tmp/debug.js",
     "docs": "typedoc src --readme none --githubPages false",
@@ -52,6 +51,6 @@
     "ts-jest": "^29.1.0",
     "typedoc": "^0.22.4",
     "typedoc-plugin-markdown": "^3.11.2",
-    "typescript": "^4.2.3"
+    "typescript": "^5.1.3"
   }
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src"
+  },
+  // unsupported by cli so need to use separate config
+  "include": ["./src"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,19 +1,16 @@
 {
   "compilerOptions": {
-    "moduleResolution": "node",
     "target": "es6",
     "module": "commonjs",
     "declaration": true,
+    "moduleResolution": "node",
     "skipLibCheck": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "downlevelIteration": true,
     "outDir": "./dist",
     "baseUrl": "./src"
-  },
-  "include": ["types/*.d.ts", "__generated__/*.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules", "src/tmp", "tmp", "dist", "e2e"]
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5068,10 +5068,10 @@ typedoc@^0.22.4:
     minimatch "^3.0.4"
     shiki "^0.9.11"
 
-typescript@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.3.tgz#39062d8019912d43726298f09493d598048c1ce3"
-  integrity sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==
+typescript@^5.1.3:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.3.tgz#8d84219244a6b40b6fb2b33cc1c062f715b9e826"
+  integrity sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==
 
 ua-parser-js@^0.7.18:
   version "0.7.27"


### PR DESCRIPTION
Here switched to testing sources instead of built modules. So we could use typescript checking. Though build is complicated because of rootDir option which requires separate tsconfig.

Also bumped to typescript v5.