### PR TITLE
Drop generic Unwrap in favor of built-in Awaited

### DIFF
--- a/src/methods/getComments.ts
+++ b/src/methods/getComments.ts
@@ -1,5 +1,4 @@
 import { gql } from "code-tag";
-import type { Unwrap } from "../types";
 import type { GithubBlog } from "../github-blog";
 import { GithubQueryParams } from "../utils/github-query";
 import { PagerParams } from "../utils/pager";
@@ -73,4 +72,4 @@ export const getComments = (blog: GithubBlog) => async (params: GetCommentsParam
 
 export type GetComments = ReturnType<typeof getComments>;
 
-export type GetCommentsResult = Unwrap<ReturnType<GetComments>>;
+export type GetCommentsResult = Awaited<ReturnType<GetComments>>;

--- a/src/methods/getLabels.ts
+++ b/src/methods/getLabels.ts
@@ -1,6 +1,5 @@
 import { gql } from "code-tag";
 import type { GithubBlog } from "../github-blog";
-import type { Unwrap } from "../types";
 import { isNonNull } from "../utils/func";
 import { PagerParams } from "../utils/pager";
 import { Label } from "../datatypes/Label";
@@ -70,4 +69,4 @@ export const getLabels = (blog: GithubBlog) => async (params?: GetLabelsParams) 
 
 export type GetLabels = ReturnType<typeof getLabels>;
 
-export type GetLabelsResult = Unwrap<ReturnType<GetLabels>>;
+export type GetLabelsResult = Awaited<ReturnType<GetLabels>>;

--- a/src/methods/getPinnedPosts.ts
+++ b/src/methods/getPinnedPosts.ts
@@ -1,5 +1,4 @@
 import { gql } from "code-tag";
-import type { Unwrap } from "../types";
 import type { GithubBlog } from "../github-blog";
 import { isNonNull } from "../utils/func";
 import { PostReduced } from "../datatypes/PostReduced";
@@ -40,4 +39,4 @@ export const getPinnedPosts = (blog: GithubBlog) => async () => {
 
 export type GetPinnedPosts = ReturnType<typeof getPinnedPosts>;
 
-export type GetPinnedPostsResult = Unwrap<ReturnType<GetPinnedPosts>>;
+export type GetPinnedPostsResult = Awaited<ReturnType<GetPinnedPosts>>;

--- a/src/methods/getPost.ts
+++ b/src/methods/getPost.ts
@@ -1,5 +1,4 @@
 import { gql } from "code-tag";
-import type { Unwrap } from "../types";
 import type { GithubBlog } from "../github-blog";
 import { Post } from "../datatypes/Post";
 import { GithubQueryParams } from "../utils/github-query";
@@ -38,4 +37,4 @@ export const getPost = (blog: GithubBlog) => async (params: GetPostParams) => {
 
 export type GetPost = ReturnType<typeof getPost>;
 
-export type GetPostResult = Unwrap<ReturnType<GetPost>>;
+export type GetPostResult = Awaited<ReturnType<GetPost>>;

--- a/src/methods/getPosts.ts
+++ b/src/methods/getPosts.ts
@@ -1,5 +1,4 @@
 import { gql } from "code-tag";
-import type { Unwrap } from "../types";
 import type { GithubBlog } from "../github-blog";
 import { GithubQueryParams } from "../utils/github-query";
 import { isNonNull } from "../utils/func";
@@ -65,4 +64,4 @@ export const getPosts = (blog: GithubBlog) => async (params: GetPostsParams) => 
 
 export type GetPosts = ReturnType<typeof getPosts>;
 
-export type GetPostsResult = Unwrap<ReturnType<GetPosts>>;
+export type GetPostsResult = Awaited<ReturnType<GetPosts>>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,1 @@
 export * from "../__generated__/index";
-
-export type Unwrap<T> = T extends Promise<infer U> ? U : never;


### PR DESCRIPTION
Awaited came in TS 4.5, after the first implementation of github-blog, so I needed to create Unwrap